### PR TITLE
Support tax on non-shipping items

### DIFF
--- a/lib/workarea/avatax/version.rb
+++ b/lib/workarea/avatax/version.rb
@@ -1,5 +1,5 @@
 module Workarea
   module Avatax
-    VERSION = "4.1.2"
+    VERSION = '4.2.0.pre'
   end
 end

--- a/test/models/workarea/pricing/calculators/avalara_tax_calculator_test.rb
+++ b/test/models/workarea/pricing/calculators/avalara_tax_calculator_test.rb
@@ -64,6 +64,49 @@ module Workarea
           assert_equal("tax", shipping_tax.price)
           assert_equal(0.24.to_m, shipping_tax.amount)
         end
+
+        def test_non_shipping_items
+          create_pricing_sku(
+            id: "SKU",
+            tax_code: "001",
+            prices: [{ regular: 5.to_m }]
+          )
+
+          create_tax_category(
+            code:  "001",
+            rates: [{ percentage: 0.06, region: "PA", country: "US" }]
+          )
+
+          order = Order.new(
+            items: [
+              {
+                requires_shipping: false,
+                price_adjustments: [
+                  {
+                    price: "item",
+                    amount: 5.to_m,
+                    data: { "tax_code" => "001" }
+                  }
+                ],
+                total_price: 5.to_m,
+              }
+            ]
+          )
+
+          AvalaraTaxCalculator.test_adjust(order)
+
+          assert_equal(2, order.items.first.price_adjustments.length)
+
+          avalara_adjustment = order.items.first.price_adjustments.last
+          assert_equal('tax', avalara_adjustment.price)
+          assert_equal(0.30.to_m, avalara_adjustment.amount)
+          assert_equal('001', avalara_adjustment.data['tax_code'])
+          assert_equal(0.06, avalara_adjustment.data['PA STATE TAX'])
+          assert_equal(
+            order.items.first.price_adjustments.first.id,
+            avalara_adjustment.data['adjustment']
+          )
+        end
       end
     end
   end

--- a/workarea-avatax.gemspec
+++ b/workarea-avatax.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency "workarea", "~> 3.x", ">= 3.2"
+  s.add_dependency 'workarea', '>= 3.5.x'
   s.add_dependency "avatax", "~> 17.0"
   s.add_dependency "hashie", "~> 3.0"
 end


### PR DESCRIPTION
Since v3.5 supports non-shipping items natively, this checks those for
taxes from Avalara.